### PR TITLE
add color picker element

### DIFF
--- a/elements/color-selector.html
+++ b/elements/color-selector.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+
+<dom-module id="color-selector">
+  <style>
+    :host {
+      height: 60px;
+      display: block;
+    }
+
+    #colors,
+    #selectedColor {
+      display: inline-block;
+      height: 100%;
+      vertical-align: top;
+    }
+
+    #selectedColor {
+      width: 200px;
+      background: #CCC;
+      font-size: 20px;
+      line-height: 60px;
+      text-align: center;
+      transition: background-color 0.5s ease;
+    }
+
+    #colors a {
+      width: 60px;
+      height: 100%;
+      display: inline-block;
+      background: #CCC;
+      border: 2px solid transparent;
+    }
+    #colors .selected {
+      border: 2px solid #333;
+    }
+  </style>
+  <template>
+    <div id="colors">
+      <template is="dom-repeat" items="{{colors}}">
+        <a href="#" class="color" data-color$="{{item}}" style$="{{cssBackground(item)}}"></a>
+      </template>
+    </div>
+    <div id="selectedColor">{{prompt}}</div>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({
+    is: "color-selector",
+
+    properties: {
+      prompt: String,
+      colors: {
+        type: 'Array',
+        value: ['#B0171F', '#DC143C', '#FF3E96', '#FF6EB4'],
+      },
+      selectedColor: {
+        type: 'String',
+        observer: 'onColorChange'
+      }
+    },
+
+    cssBackground: function(color) {
+      return 'background: ' + color;
+    },
+
+    listeners: {
+      'colors.click': 'onColorClick'
+    },
+
+    onColorClick: function(ev) {
+      ev.preventDefault();
+
+      var selectedColor = Polymer.dom(this.$.colors).querySelector('.selected');
+      if(selectedColor) {
+        selectedColor.classList.remove('selected');
+      }
+
+      var el = ev.target;
+      el.classList.add('selected');
+      this.selectedColor = el.dataset.color;
+    },
+
+    onColorChange: function(newValue, oldValue) {
+      this.$.selectedColor.innerHTML = newValue;
+      this.$.selectedColor.style.background = newValue;
+    }
+  });
+</script>

--- a/elements/color-selector.html
+++ b/elements/color-selector.html
@@ -5,6 +5,7 @@
     :host {
       height: 60px;
       display: block;
+      margin: 0.25em;
     }
 
     #colors,
@@ -15,7 +16,7 @@
     }
 
     #selectedColor {
-      width: 200px;
+      width: 250px;
       background: #CCC;
       font-size: 20px;
       line-height: 60px;
@@ -52,7 +53,18 @@
       prompt: String,
       colors: {
         type: 'Array',
-        value: ['#B0171F', '#DC143C', '#FF3E96', '#FF6EB4'],
+        value: function (i) {
+
+          var defaultColors = ['#B0171F', '#DC143C', '#FF3E96', '#FF6EB4'];
+
+          try {
+            var customColors = JSON.parse(i.colors);
+            i.colors = customColors;
+          }
+          catch(e) {
+            return defaultColors;
+          }
+        },
       },
       selectedColor: {
         type: 'String',

--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
             </div>
           </div>
           <hr />
-          <color-selector prompt="Select a color"></color-selector>
+          <color-selector prompt="Select a (default) color"></color-selector>
+          <color-selector colors='["#ccc", "#111"]' prompt="Select a (custom) color"></color-selector>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js"></script>
     <link rel="import" href="elements/page-heading.html">
     <link rel="import" href="elements/picture-frame.html">
+    <link rel="import" href="elements/color-selector.html">
   </head>
   <body>
     <div class="container-fluid">
@@ -26,6 +27,8 @@
               <picture-frame></picture-frame>
             </div>
           </div>
+          <hr />
+          <color-selector prompt="Select a color"></color-selector>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This element demonstrates....
- styling a shadow DOM host (:host)
- using attribute binding (style=$, class=$, ...)
- using computed properties as a decorator
- property observers
- listening for dom events (note the format: '[#ID].[event]')
- referencing cached elements by id (this.$.[ID])
